### PR TITLE
accept lower versions of polymer dependencies (down to 0.5.4)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "polymer": "Polymer/polymer#~0.5.6",
+    "polymer": "Polymer/polymer#~0.5.4",
     "core-icons": "Polymer/core-icons#~0.5.6",
-    "core-list": "Polymer/core-list#~0.5.6"
+    "core-list": "Polymer/core-list#~0.5.5"
   }
 }


### PR DESCRIPTION
We don't want to update our polymer dependencies just yet, so we need these packages to accept our version (0.5.4).