### PR TITLE
make io-string use a span when disabled for ease of styling.

### DIFF
--- a/io-string.html
+++ b/io-string.html
@@ -24,14 +24,29 @@ I/O element for string data type.
       }
     </style>
     <content></content>
-    <input id="value" class="io-editor" tabindex="0" spellcheck="false" contenteditable value="{{immediateValue}}" placeholder="{{placeholder}}" flex></input>
+    <template if="{{disabled}}">
+      <span class="io-editor">{{value}}</span>
+    </template>
+    <template if="{{!disabled}}">
+      <input id="value"
+        class="io-editor"
+        tabindex="0"
+        spellcheck="false"
+        autocomplete="{{autocomplete}}"
+        value="{{immediateValue}}"
+        placeholder="{{placeholder}}"
+        flex>
+      </input>
+    </template>
   </template>
   <script type="text/javascript">
     // TODO: optimize and prevent pasting of breaklines.
     (function() {
       Polymer({
         publish: {
-          multiline: {value: false, reflect: true}
+          // TODO: allow multiline input
+          // multiline: {value: false, reflect: true},
+          autocomplete: false
         },
         placeholder: "string",
         eventDelegates: {


### PR DESCRIPTION
it is difficult to fit <input> to its content width, and
not necessary to use <input> unless the user is inputting
the value.

also make autocomplete configurable and default off.